### PR TITLE
🔧 Update debug build configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,8 @@ android {
             )
         }
         debug {
+            applicationIdSuffix = ".debug"
+            resValue("string", "app_name", "@string/app_name_debug")
             isDebuggable = true
             versionNameSuffix = "-debug"
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name" translatable="false">Concert History</string>
+    <string name="app_name_debug" translatable="false">Debug Concert History</string>
 
     <!-- Descriptions -->
     <string name="desc_back">Navigate Back</string>


### PR DESCRIPTION
- Add applicationIdSuffix to differentiate between release and debug
- Change App Name in debug variant to @string/app_name_debug

This pull request includes changes to the `app/build.gradle.kts` and `strings.xml` files to improve the debug build configuration and provide a distinct application name for the debug version.

### Debug Build Configuration Improvements:

* [`app/build.gradle.kts`](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R68-R69): Added `applicationIdSuffix` and `resValue` for the debug build type to distinguish the debug version of the app.
* [`app/src/main/res/values/strings.xml`](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R3): Added a new string resource `app_name_debug` for the debug version of the application.